### PR TITLE
feat: add tint, shade and mix methods

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -2,4 +2,7 @@ import { defineConfig } from 'father';
 
 export default defineConfig({
   plugins: ['@rc-component/father-plugin'],
+  targets: {
+    chrome: 51, // es2015, aligned with @ctrl/tinycolor
+  },
 });

--- a/src/FastColor.ts
+++ b/src/FastColor.ts
@@ -134,6 +134,41 @@ export class FastColor {
     return new FastColor({ h, s, l, a: this.a });
   }
 
+  /**
+   * Mix the color with pure white, from 0 to 100.
+   * Providing 0 will do nothing, providing 100 will always return white.
+   */
+  tint(amount = 10): FastColor {
+    return this.mix({ r: 255, g: 255, b: 255, a: 1 }, amount);
+  }
+
+  /**
+   * Mix the color with pure black, from 0 to 100.
+   * Providing 0 will do nothing, providing 100 will always return black.
+   */
+  shade(amount = 10): FastColor {
+    return this.mix({ r: 0, g: 0, b: 0, a: 1 }, amount);
+  }
+
+  /**
+   * Mix the current color a given amount with another color, from 0 to 100.
+   * 0 means no mixing (return current color).
+   */
+  mix(color: ColorInput, amount = 50): FastColor {
+    const rgb1 = this.toRgb();
+    const rgb2 = new FastColor(color).toRgb();
+
+    const p = amount / 100;
+    const rgba = {
+      r: (rgb2.r - rgb1.r) * p + rgb1.r,
+      g: (rgb2.g - rgb1.g) * p + rgb1.g,
+      b: (rgb2.b - rgb1.b) * p + rgb1.b,
+      a: (rgb2.a - rgb1.a) * p + rgb1.a,
+    };
+
+    return new FastColor(rgba);
+  }
+
   getAlpha(): number {
     return this.a;
   }
@@ -235,7 +270,8 @@ export class FastColor {
     return this._brightness;
   }
 
-  onBackground(bg: FastColor): FastColor {
+  onBackground(background: ColorInput): FastColor {
+    const bg = new FastColor(background);
     const alpha = this.a + bg.a * (1 - this.a);
 
     return new FastColor({
@@ -246,8 +282,9 @@ export class FastColor {
     });
   }
 
-  setAlpha(alpha: number): void {
+  setAlpha(alpha: number): FastColor {
     this.a = alpha;
+    return this;
   }
 
   toHexString(): string {


### PR DESCRIPTION
- setAlpha 方法返回 this，支持链式调用，与 @ctrl/tinycolor 保持一致
- onBackground 支持 ColorInput，与 @ctrl/tinycolor 保持一致
- 增加 tint, shade 和 mix 方法，与 @ctrl/tinycolor 保持一致
- 构建目标改为 chrome 51 (es2015)，与 @ctrl/tinycolor 保持一致