### PR TITLE
chore: align the logic as tiny-color

### DIFF
--- a/src/FastColor.ts
+++ b/src/FastColor.ts
@@ -13,7 +13,13 @@ type ParseNumber = (num: number, txt: string, index: number) => number;
  * When `base` is provided, the percentage value will be divided by `base`.
  */
 function splitColorStr(str: string, parseNum: ParseNumber): number[] {
-  const match: string[] = str.match(/\d*\.?\d+%?/g) || [];
+  const match: string[] =
+    str
+      // Remove str before `(`
+      .replace(/^[^(]*\((.*)/, '$1')
+      // Remove str after `)`
+      .replace(/\).*/, '')
+      .match(/\d*\.?\d+%?/g) || [];
   const numList = match.map((item) => parseFloat(item));
 
   for (let i = 0; i < 3; i += 1) {
@@ -29,6 +35,10 @@ function splitColorStr(str: string, parseNum: ParseNumber): number[] {
   }
 
   return numList;
+}
+
+function inRange(val: number, max = 255, min = 0) {
+  return typeof val === 'number' && val >= min && val <= max;
 }
 
 const parseHSVorHSL: ParseNumber = (num, _, index) =>
@@ -122,18 +132,10 @@ export class FastColor {
 
   get isValid() {
     return (
-      typeof this.r === 'number' &&
-      this.r >= 0 &&
-      this.r <= 255 &&
-      typeof this.g === 'number' &&
-      this.g >= 0 &&
-      this.g <= 255 &&
-      typeof this.b === 'number' &&
-      this.b >= 0 &&
-      this.b <= 255 &&
-      typeof this.a === 'number' &&
-      this.a >= 0 &&
-      this.a <= 1
+      inRange(this.r) &&
+      inRange(this.g) &&
+      inRange(this.b) &&
+      inRange(this.a, 1)
     );
   }
 

--- a/tests/css-rgb-syntax.test.ts
+++ b/tests/css-rgb-syntax.test.ts
@@ -150,4 +150,13 @@ describe('css rgb() syntax', () => {
       a: 1,
     });
   });
+
+  it('rgb with extra stop', () => {
+    expect(new FastColor('rgb(255, 0, 0) 0%').toRgb()).toEqual({
+      r: 255,
+      g: 0,
+      b: 0,
+      a: 1,
+    });
+  });
 });

--- a/tests/css-rgb-syntax.test.ts
+++ b/tests/css-rgb-syntax.test.ts
@@ -152,10 +152,10 @@ describe('css rgb() syntax', () => {
   });
 
   it('rgb with extra stop', () => {
-    expect(new FastColor('rgb(255, 0, 0) 0%').toRgb()).toEqual({
+    expect(new FastColor('rgb(255, 90, 30) 0%').toRgb()).toEqual({
       r: 255,
-      g: 0,
-      b: 0,
+      g: 90,
+      b: 30,
       a: 1,
     });
   });


### PR DESCRIPTION
`rgb(255,255,255) 0%` 在 TinyColor 会被当成 `rgb(255,255,255)` 处理，对齐这一行为。