### PR TITLE
fix: default fill logic

### DIFF
--- a/src/FastColor.ts
+++ b/src/FastColor.ts
@@ -75,7 +75,12 @@ export class FastColor {
   private _brightness?: number;
 
   constructor(input: ColorInput) {
-    if (typeof input === 'string') {
+    if (!input) {
+      this.r = 0;
+      this.g = 0;
+      this.b = 0;
+      this.a = 1;
+    } else if (typeof input === 'string') {
       const trimStr = input.trim();
 
       function matchPrefix(prefix: string) {

--- a/tests/ctrl-tinycolor/TinyColor.test.ts
+++ b/tests/ctrl-tinycolor/TinyColor.test.ts
@@ -263,4 +263,13 @@ describe('@ctrl/tinycolor compatibility', () => {
         .toRgbString(),
     ).toBe('rgb(0,0,255)');
   });
+
+  it('default of empty', () => {
+    expect(new FastColor('').toRgb()).toEqual({
+      r: 0,
+      g: 0,
+      b: 0,
+      a: 1,
+    });
+  });
 });


### PR DESCRIPTION
对齐 tinyColor，当构造函数为空时，提供 `rgb(0,0,0)` 的颜色而不是一个无效颜色。