### PR TITLE
fix: always return construct instance instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "@ant-design/fast-color",
   "version": "2.0.1",
   "description": "fast and small color class",
-  "engines": {
-    "node": ">=8.x"
-  },
   "keywords": [
     "react",
     "react-component",
@@ -12,35 +9,38 @@
     "trigger"
   ],
   "homepage": "https://github.com/ant-design/fast-color",
-  "author": {
-    "name": "Guo Yunhe",
-    "email": "i@guoyunhe.me",
-    "url": "https://guoyunhe.me/"
+  "bugs": {
+    "url": "https://github.com/ant-design/fast-color/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/ant-design/fast-color.git"
   },
-  "bugs": {
-    "url": "https://github.com/ant-design/fast-color/issues"
+  "license": "MIT",
+  "author": {
+    "name": "Guo Yunhe",
+    "email": "i@guoyunhe.me",
+    "url": "https://guoyunhe.me/"
   },
+  "main": "./lib/index",
+  "module": "./es/index",
   "files": [
     "es",
     "lib"
   ],
-  "license": "MIT",
-  "main": "./lib/index",
-  "module": "./es/index",
   "scripts": {
-    "start": "dumi dev",
     "bench": "vitest bench",
     "build": "dumi build",
     "compile": "father build",
-    "prepublishOnly": "npm run compile && np --yolo --no-publish",
-    "lint": "eslint src/ tests/ --ext .tsx,.ts,.jsx,.js",
-    "test": "rc-test",
     "coverage": "rc-test --coverage",
-    "now-build": "npm run build"
+    "lint": "eslint src/ tests/ --ext .tsx,.ts,.jsx,.js",
+    "now-build": "npm run build",
+    "prepublishOnly": "npm run compile",
+    "start": "dumi dev",
+    "test": "rc-test"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.24.7"
   },
   "devDependencies": {
     "@ctrl/tinycolor": "^4.1.0",
@@ -58,7 +58,7 @@
     "typescript": "^5.4.5",
     "vitest": "^1.6.0"
   },
-  "dependencies": {
-    "@babel/runtime": "^7.24.7"
+  "engines": {
+    "node": ">=8.x"
   }
 }

--- a/src/FastColor.ts
+++ b/src/FastColor.ts
@@ -172,7 +172,7 @@ export class FastColor {
   setHue(value: number) {
     const hsv = this.toHsv();
     hsv.h = value;
-    return new FastColor(hsv);
+    return this._c(hsv);
   }
 
   // ======================= Getter =======================
@@ -262,7 +262,7 @@ export class FastColor {
     if (l < 0) {
       l = 0;
     }
-    return new FastColor({ h, s, l, a: this.a });
+    return this._c({ h, s, l, a: this.a });
   }
 
   lighten(amount = 10): FastColor {
@@ -272,7 +272,7 @@ export class FastColor {
     if (l > 1) {
       l = 1;
     }
-    return new FastColor({ h, s, l, a: this.a });
+    return this._c({ h, s, l, a: this.a });
   }
 
   /**
@@ -280,7 +280,7 @@ export class FastColor {
    * 0 means no mixing (return current color).
    */
   mix(input: ColorInput, amount = 50): FastColor {
-    const color = new FastColor(input);
+    const color = this._c(input);
 
     const p = amount / 100;
     const rgba = {
@@ -290,7 +290,7 @@ export class FastColor {
       a: (color.a - this.a) * p + this.a,
     };
 
-    return new FastColor(rgba);
+    return this._c(rgba);
   }
 
   /**
@@ -310,13 +310,19 @@ export class FastColor {
   }
 
   onBackground(background: ColorInput): FastColor {
-    const bg = new FastColor(background);
+    const bg = this._c(background);
     const alpha = this.a + bg.a * (1 - this.a);
 
-    return new FastColor({
-      r: Math.round((this.r * this.a + bg.r * bg.a * (1 - this.a)) / alpha),
-      g: Math.round((this.g * this.a + bg.g * bg.a * (1 - this.a)) / alpha),
-      b: Math.round((this.b * this.a + bg.b * bg.a * (1 - this.a)) / alpha),
+    const calc = (key: string) => {
+      return Math.round(
+        (this[key] * this.a + bg[key] * bg.a * (1 - this.a)) / alpha,
+      );
+    };
+
+    return this._c({
+      r: calc('r'),
+      g: calc('g'),
+      b: calc('b'),
       a: alpha,
     });
   }
@@ -341,7 +347,7 @@ export class FastColor {
   }
 
   clone(): this {
-    return new (this.constructor as Constructor<this>)(this);
+    return this._c(this);
   }
 
   // ======================= Format =======================
@@ -412,10 +418,14 @@ export class FastColor {
 
   // ====================== Privates ======================
   /** Return a new FastColor object with one channel changed */
-  _sc(rgb: string, value: number, max?: number): FastColor {
+  private _sc(rgb: string, value: number, max?: number): FastColor {
     const clone = this.clone();
     clone[rgb] = limitRange(value, max);
     return clone;
+  }
+
+  private _c(input: ColorInput): this {
+    return new (this.constructor as Constructor<this>)(input);
   }
 
   private getMax() {

--- a/src/FastColor.ts
+++ b/src/FastColor.ts
@@ -1,5 +1,7 @@
 import type { ColorInput, HSL, HSV, OptionalA, RGB } from './types';
 
+type Constructor<T> = new (...args: any[]) => T;
+
 type ParseNumber = (num: number, txt: string, index: number) => number;
 
 /**
@@ -338,8 +340,8 @@ export class FastColor {
     );
   }
 
-  clone(): FastColor {
-    return new FastColor(this);
+  clone(): this {
+    return new (this.constructor as Constructor<this>)(this);
   }
 
   // ======================= Format =======================

--- a/tests/instance.test.ts
+++ b/tests/instance.test.ts
@@ -1,0 +1,30 @@
+import { FastColor } from '../src';
+
+describe('instance', () => {
+  describe('clone', () => {
+    it('clone should return same construct', () => {
+      const base = new FastColor('#1677ff');
+      const turn = base.clone();
+
+      expect(turn instanceof FastColor);
+    });
+
+    it('extends should be same', () => {
+      class Little extends FastColor {
+        constructor() {
+          super('#1677ff');
+        }
+
+        bamboo() {
+          return 'beauty';
+        }
+      }
+
+      const base = new Little();
+      const turn = base.clone();
+
+      expect(turn instanceof Little);
+      expect(turn.bamboo()).toBe('beauty');
+    });
+  });
+});


### PR DESCRIPTION
始终返回 构造 对象，以支持通过继承扩展的对象计算后返回 FastColor 的问题。