### PR TITLE
chore: adjust default init and compatible version

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -3,6 +3,9 @@ import { defineConfig } from 'father';
 export default defineConfig({
   plugins: ['@rc-component/father-plugin'],
   targets: {
-    chrome: 74, // es2015, aligned with @ctrl/tinycolor
+    // It's annoying ts will add prop def in class.
+    // We have to use low version to compatible with this
+    // Since some user not upgrade their webpack.
+    chrome: 73,
   },
 });

--- a/src/FastColor.ts
+++ b/src/FastColor.ts
@@ -61,27 +61,27 @@ export class FastColor {
   /**
    * All FastColor objects are valid. So isValid is always true. This property is kept to be compatible with TinyColor.
    */
-  isValid: boolean;
+  isValid: boolean = true;
 
   /**
    * Red, R in RGB
    */
-  r: number;
+  r: number = 0;
 
   /**
    * Green, G in RGB
    */
-  g: number;
+  g: number = 0;
 
   /**
    * Blue, B in RGB
    */
-  b: number;
+  b: number = 0;
 
   /**
    * Alpha/Opacity, A in RGBA/HSLA
    */
-  a: number;
+  a: number = 1;
 
   // HSV privates
   private _h?: number;
@@ -96,12 +96,6 @@ export class FastColor {
   private _brightness?: number;
 
   constructor(input: ColorInput) {
-    this.isValid = true;
-    this.r = 0;
-    this.g = 0;
-    this.b = 0;
-    this.a = 1;
-
     /**
      * Always check 3 char in the object to determine the format.
      * We not use function in check to save bundle size.


### PR DESCRIPTION
在 74 版本中，field 定义会被内联到 class 定义中，这使得旧版本的 webpack 编译会报错（即便浏览器已经支持了该写法）。
调整版本，让 father 编译时进行初始化，减少额外的定义次数。